### PR TITLE
Make AVR include file conditional so the library runs on esp8266

### DIFF
--- a/Adafruit_HTU21DF.cpp
+++ b/Adafruit_HTU21DF.cpp
@@ -15,7 +15,9 @@
  ****************************************************/
 
 #include "Adafruit_HTU21DF.h"
+#if defined(__AVR__)
 #include <util/delay.h>
+#endif
 
 Adafruit_HTU21DF::Adafruit_HTU21DF() {
 }


### PR DESCRIPTION
Minor change to make the library work on the ESP8266 HUZZAH breakout board.